### PR TITLE
Uglifier-friendly resolve objects in $routeProvider

### DIFF
--- a/chapter4/guthub/app/scripts/controllers/controllers.js
+++ b/chapter4/guthub/app/scripts/controllers/controllers.js
@@ -8,25 +8,25 @@ app.config(['$routeProvider', function($routeProvider) {
       when('/', {
         controller: 'ListCtrl',
         resolve: {
-          recipes: function(MultiRecipeLoader) {
+          recipes: ["MultiRecipeLoader", function(MultiRecipeLoader) {
             return MultiRecipeLoader();
-          }
+          }]
         },
         templateUrl:'/views/list.html'
       }).when('/edit/:recipeId', {
         controller: 'EditCtrl',
         resolve: {
-          recipe: function(RecipeLoader) {
+          recipe: ["RecipeLoader", function(RecipeLoader) {
             return RecipeLoader();
-          }
+          }]
         },
         templateUrl:'/views/recipeForm.html'
       }).when('/view/:recipeId', {
         controller: 'ViewCtrl',
         resolve: {
-          recipe: function(RecipeLoader) {
+          recipe: ["RecipeLoader", function(RecipeLoader) {
             return RecipeLoader();
-          }
+          }]
         },
         templateUrl:'/views/viewRecipe.html'
       }).when('/new', {


### PR DESCRIPTION
This example cannot be uglified because it's missing explicit dependency injection for objects being `resolve`d in `$routeProvider`. Parameters `MultiRecipeLoader` and `RecipeLoader` must be specified in strings.
