### PR TITLE
Instead of using $parent and an isolate scope, use $parse.

### DIFF
--- a/chapter8/datepicker/app.js
+++ b/chapter8/datepicker/app.js
@@ -5,5 +5,6 @@ app.controller('MainCtrl', function($scope) {
   $scope.currentDate = '';
   $scope.updateMyText = function(date) {
     $scope.myText = 'Selected';
+    console.log('date=currentDate: ', date, $scope.currentDate);
   };
 });

--- a/chapter8/datepicker/datepicker.js
+++ b/chapter8/datepicker/datepicker.js
@@ -1,19 +1,16 @@
 angular.module('myApp.directives', [])
-  .directive('datepicker', function() {
+  .directive('datepicker', function($parse) {
     return {
       // Enforce the angularJS default of restricting the directive to
       // attributes only
       restrict: 'A',
       // Always use along with an ng-model
       require: '?ngModel',
-      // This method needs to be defined and passed in from the
-      // passed in to the directive from the view controller
-      scope: {
-        select: '&'        // Bind the select function we refer to the right scope
-      },
       link: function(scope, element, attrs, ngModel) {
         if (!ngModel) return;
-
+        // the "select" argument defines which function the directive
+        // should call when a new date is selected via the UI
+        var selectFn = $parse(attrs.select);
         var optionsObj = {};
 
         optionsObj.dateFormat = 'mm/dd/yy';
@@ -27,9 +24,9 @@ angular.module('myApp.directives', [])
 
         optionsObj.onSelect = function(dateTxt, picker) {
           updateModel(dateTxt);
-          if (scope.select) {
+          if (selectFn) {
             scope.$apply(function() {
-              scope.select({date: dateTxt});
+              selectFn(scope, {date: dateTxt});
             });
           }
         };

--- a/chapter8/datepicker/index.html
+++ b/chapter8/datepicker/index.html
@@ -17,7 +17,7 @@
 </head>
 
 <body ng-controller="MainCtrl">
-<input id="dateField" datepicker ng-model="$parent.currentDate" select="updateMyText(date)">
+<input id="dateField" datepicker ng-model="currentDate" select="updateMyText(date)">
 <br/>
 {{myText}} - {{currentDate}}
 </body>


### PR DESCRIPTION
Instead of using $parent and an isolate scope, $parse can be used to specify which scope function the directive should call when a date is selected via the jQuery plugin UI.

There have been some discussions on StackOverflow about using ngModel
and isolate scopes.  The general concensus seems to be "don't":

http://stackoverflow.com/questions/11896732/ngmodel-and-component-with-isolated-scope

http://stackoverflow.com/questions/15419629/angularjs-two-way-data-binding-fails-if-element-has-ngmodel-and-a-custom-direct/15419873#15419873
"Since you are trying to create a component that must interact with other
directives, an isolate scope is not the best choice."
